### PR TITLE
rubyバージョン修正

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM ruby:3.2.0
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 
 COPY Gemfile* ./

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM ruby:3.2.0
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs default-mysql-client
 
 ENV APP_PATH /sample


### PR DESCRIPTION
DockerのRubyの公式のイメージは3.2を指定すると最新の3.2.1を指定しまいます。
そのため、buildしなおした際や新しく環境構築をした際に矛盾してエラーが出るので、取得するバージョンを固定しました。