### PR TITLE
React側のルーティングを行うため、ReactRouterを導入しました

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -14,6 +14,7 @@
     "graphql": "^16.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.8.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1,6 +1,7 @@
 import "./App.css";
 import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
 import { Sample } from "./Sample";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 const client = new ApolloClient({
   uri: "https://tdiaryapi.herokuapp.com/graphql",
@@ -9,9 +10,13 @@ const client = new ApolloClient({
 
 function App() {
   return (
-    <ApolloProvider client={client}>
-      <Sample />
-    </ApolloProvider>
+    <BrowserRouter>
+      <ApolloProvider client={client}>
+        <Routes>
+          <Route path="/sample" element={<Sample />} />
+        </Routes>
+      </ApolloProvider>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/app/yarn.lock
+++ b/frontend/app/yarn.lock
@@ -1592,6 +1592,11 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@remix-run/router@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.2.tgz#58cd2bd25df2acc16c628e1b6f6150ea6c7455bc"
+  integrity sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -7572,6 +7577,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.8.1.tgz#7e136b67d9866f55999e9a8482c7008e3c575ac9"
+  integrity sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==
+  dependencies:
+    "@remix-run/router" "1.3.2"
+    react-router "6.8.1"
+
+react-router@6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.8.1.tgz#e362caf93958a747c649be1b47cd505cf28ca63e"
+  integrity sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==
+  dependencies:
+    "@remix-run/router" "1.3.2"
 
 react-scripts@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## レビュー観点
よさそうか

## 導入したもの
https://reactrouter.com/en/main

API側のルーティングはroute.rbに書くだけでできますが、React側はライブラリを使用した方が楽なので入れました。

## 使い方
```tsx
function App() {
  return (
    <BrowserRouter>
      <ApolloProvider client={client}>
        <Routes>
          <Route path="/sample" element={<Sample />} />
        </Routes>
      </ApolloProvider>
    </BrowserRouter>
  );
}
```

こんな感じで`<Route>`要素の中でpathとelementを指定していく。
`App.tsx`が大きくなっていくイメージだと思います。

## 動作確認
http://localhost:8080/sample
にアクセスしてロード中→HelloWorldが表示されればOK