### PR TITLE
環境初回起動時にrails db:create, db:migrateを自動で行う処理を追加

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,8 @@ jobs:
       - name: Setup Docker
         shell: bash
         run: |
-          chmod +x ./backend/entrypoint.sh
-          chmod +x ./backend/entrypoint-script/*.sh
           docker-compose build
           docker-compose up -d
-          sleep 30
-          docker-compose run api rails db:create db:migrate
         env:
           RAILS_ENV: test
 

--- a/backend/entrypoint-script/after-db-config.sh
+++ b/backend/entrypoint-script/after-db-config.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+rm -f tmp/pids/server.pid
+
+while true; do
+  if rails db:version >/dev/null 2>&1; then
+    break
+  else
+    echo "Creating database..."
+    rails db:create
+    echo "Start Migration..."
+    rails db:migrate
+  fi
+
+  if rails db:version >/dev/null 2>&1; then
+    break
+  else
+    echo "Failed to db initializetion, waiting for 15 seconds..."
+    sleep 15
+  fi
+done
+
+rails s -p 3000 -b '0.0.0.0'

--- a/backend/entrypoint-script/wait-for-it.sh
+++ b/backend/entrypoint-script/wait-for-it.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+
+    ./entrypoint-script/after-db-config.sh
+    
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
 
+chmod +x ./entrypoint-script/*
 ./entrypoint-script/wait-for-it.sh db:3306

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-rm -f /sample/tmp/pids/server.pid
+./entrypoint-script/wait-for-it.sh db:3306
 
 exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     build:
       context: ./backend/
       dockerfile: Dockerfile.dev
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
     image: rails:dev
     volumes:
       - ./backend:/sample
@@ -23,6 +22,7 @@ services:
       RAILS_ENV: development
     ports:
       - 3000:3000
+    entrypoint: ./entrypoint.sh
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       GITHUB_ACTIONS: ${GITHUB_ACTIONS:-false}
     ports:
       - 3000:3000
-    entrypoint: ./entrypoint.sh
     depends_on:
       - db
 


### PR DESCRIPTION
## 変更の概要
- #24 
- entrypoint.shの内容を変更し、環境初回起動時にrails db:create, db:migrateを自動で行う処理を追加

## なぜこの変更をするのか

* 初回環境作成時のみrails db:create, db:migrateをしていないことで、localhost:3000にアクセスするとNo databaseとなるため

## やったこと

* [x] wait-for-itを導入し、dbコンテナがlisten状態になったら初めてapiコンテナを起動するように変更
* [x] after-db-config.shでdb起動後に行う処理を記載
* [x] mysqlは初回起動時database initが行われ、サーバーがrestartするため、apiコンテナでrails db:create等が失敗した場合は15秒後に再度実行し、成功するまでこれを続ける処理を記載

## 変更内容

* apiコンテナに対するCMD処理を廃止しENTRYPOINTに集約
* entrypoint-scriptフォルダを作成し、entrypoint.shで参照
* wait-for-it.shの導入

## 影響範囲

* 初回環境作成時のみ所望のrails dbに関するコマンドが実行されます
* 既存環境に適用される場合、並行で立ち上がっていたapiコンテナが、dbコンテナ起動後に起動します

## どうやるのか
新規環境、既存環境どちらにおいても以下コマンドを実行してください
`docker compose build`
`docker compose up`


## 課題

* entrypoint用のフォルダ構成が不自然な気がしますが、何かいい案があれば教えてください

## 備考
after-db-config.shに記載した内容をそのままentrypoint.shに記載してもエラーexitされます。wait-for-itでdbコンテナの起動を待つのは必須のようです。

* その他に伝えたいこと
docker公式でもwait-for-itについて触れられており、大規模開発ではないため今回使用しました。
https://docs.docker.jp/compose/startup-order.html