### PR TITLE
Setting prettier

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
+  "semi": false,
   "trailingComma": "none"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "format": "prettier --write src/**/*.{ts,tsx}"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,9 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import App from "./App";
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import App from './App'
 
-test("renders learn react link", () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});
+test('renders learn react link', () => {
+  render(<App />)
+  const linkElement = screen.getByText(/learn react/i)
+  expect(linkElement).toBeInTheDocument()
+})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,12 @@
-import "./App.css";
-import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
-import { Sample } from "./Sample";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import './App.css'
+import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client'
+import { Sample } from './Sample'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
 
 const client = new ApolloClient({
-  uri: "https://tdiaryapi.herokuapp.com/graphql",
-  cache: new InMemoryCache(),
-});
+  uri: 'https://tdiaryapi.herokuapp.com/graphql',
+  cache: new InMemoryCache()
+})
 
 function App() {
   return (
@@ -17,7 +17,7 @@ function App() {
         </Routes>
       </ApolloProvider>
     </BrowserRouter>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/frontend/src/Sample.tsx
+++ b/frontend/src/Sample.tsx
@@ -1,17 +1,17 @@
-import React from "react";
-import { useQuery, gql } from "@apollo/client";
+import React from 'react'
+import { useQuery, gql } from '@apollo/client'
 
 const testField = gql`
   query GetTestField {
     testField
   }
-`;
+`
 
 export const Sample = () => {
-  const { loading, error, data } = useQuery(testField);
+  const { loading, error, data } = useQuery(testField)
 
-  if (loading) return <>'ロード中....'</>;
-  if (error) return <>`Error ${error.message}`;</>;
+  if (loading) return <>'ロード中....'</>
+  if (error) return <>`Error ${error.message}`;</>
 
-  return <>{data.testField}</>;
-};
+  return <>{data.testField}</>
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,19 +1,17 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import "./index.css";
-import App from "./App";
-import reportWebVitals from "./reportWebVitals";
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import './index.css'
+import App from './App'
+import reportWebVitals from './reportWebVitals'
 
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-);
+)
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+reportWebVitals()

--- a/frontend/src/reportWebVitals.ts
+++ b/frontend/src/reportWebVitals.ts
@@ -1,15 +1,15 @@
-import { ReportHandler } from "web-vitals";
+import { ReportHandler } from 'web-vitals'
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      getCLS(onPerfEntry)
+      getFID(onPerfEntry)
+      getFCP(onPerfEntry)
+      getLCP(onPerfEntry)
+      getTTFB(onPerfEntry)
+    })
   }
-};
+}
 
-export default reportWebVitals;
+export default reportWebVitals

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom";
+import '@testing-library/jest-dom'


### PR DESCRIPTION
## 概要
[Prettierの設定を見直してカンマがつかないようにしたい](https://github.com/yuki-snow1823/diary/issues/14)の対応
- 他のPR見る限りCIでprettierは実行されていたが、.prettierrcがなくて整形するルールが何もないためにスルーされている感じになっていた（多分）
- ローカルでもコマンド叩いて整形できた方が良いかと思ったのでpackage.jsonにscriptを追加
- prettierrcのルールとしては下記を追加
　- 末尾のカンマの削除
　- 末尾のセミコロンの削除
　- シングルクォートをtrue（個人的な好み、ダブルクォートの方がいいぜ！って方がいらっしゃったら合わせます！）

## 動作確認
- ローカルで`yarn run format`で整形されること
- このPRのCIが走った時に自動整形がされていること
    - https://github.com/yuki-snow1823/diary/pull/27/commits/3fe56f2bf4429d9c5ada0f7d60e4e7651727750e で整形されているので良さそう
