### PR TITLE
タイムゾーンを日本時間に設定する

### DIFF
--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -15,7 +15,8 @@ module Backend
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Asia/Tokyo"
+    config.active_record.default_timezone = :local
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Only loads a smaller set of middleware suitable for API only apps.


### PR DESCRIPTION
## 概要
タイムゾーンを日本時間に設定します。

## issue
https://github.com/yuki-snow1823/diary/issues/29

## 実装方法

1. config/application.rbにtimezoneを下記のように設定。

```
config.time_zone = "Asia/Tokyo"
config.active_record.default_timezone = :local
```

2. railsを立ち上げ直して変更内容を反映させる
3. Graphqlにて下記クエリを実行しデータを作成。変更が反映されているかを確認
