### PR TITLE
記事の削除機能を作る

### DIFF
--- a/backend/app/graphql/mutations/delete_journal.rb
+++ b/backend/app/graphql/mutations/delete_journal.rb
@@ -1,0 +1,18 @@
+module Mutations
+  class DeleteJournal < Mutations::BaseMutation
+    field :journal, Types::JournalType, null: false
+
+    argument :journal_id, Integer, required: true
+
+    def resolve(journal_id:)
+      journal = Journal.find(journal_id).destroy
+
+      {
+        journal:
+      }
+
+    rescue => e
+      GraphQL::ExecutionError.new(e.message)
+    end
+  end
+end

--- a/backend/app/graphql/mutations/delete_journal.rb
+++ b/backend/app/graphql/mutations/delete_journal.rb
@@ -10,8 +10,7 @@ module Mutations
       {
         journal:
       }
-
-    rescue => e
+    rescue StandardError => e
       GraphQL::ExecutionError.new(e.message)
     end
   end

--- a/backend/app/graphql/types/mutation_type.rb
+++ b/backend/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
     field :create_journal, mutation: Mutations::CreateJournal
+    field :delete_journal, mutation: Mutations::DeleteJournal
   end
 end


### PR DESCRIPTION
## 対象Issue

close #28 

## やったこと

既に実装されている[createJournal](https://github.com/yuki-snow1823/diary/pull/17)で作成された記事をidを指定して削除することができるdeleteJournalを実装した

エラーハンドリングはGraphQL::ExecutionErrorに全て任せている

## やらないこと

GraphQL::ExecutionError以外でのエラーハンドリング

## 動作確認

### 前提条件

id=1 のuser が作成されていること（ターミナルにて下記のコマンドで作成可能）

```
curl -X POST http://localhost:3000/auth -d '[name]=test&[email]=test2@example.com&[password]=password&[password_confirmation]=password'
```

ここより下記の手順は
http://localhost:3000/graphiql
にて確認する

### 正常動作

#### 手順１：記事作成

createJournalにて記事を作成する

```
mutation{
  createJournal(input: {
    title: "title",
    userId: 1,
    content: "a beautiful day"
  }) {
    journal {
      id
    }
    }
}
```
#### 手順２：記事確認

queryにて記事が作成されていることを確認する

```
query{
  journals {
    id
  }
}
```

#### 手順３：記事削除

deleteJournalにて記事を削除する

```
mutation{
  deleteJournal(input: {
    journalId: 1,
  }) {
    journal {
      id
    }
    }
}
```

※ journalIdは手順2で確認したidに適宜読み替え

#### 手順４：記事確認

手順２と同様のqueryを再度叩き、手順３で指定したjournalIdのjournalが返ってこないことを確認する

```
query{
  journals {
    id
  }
}
```

### 異常動作

正常動作の手順３にて存在しないjournalIdを指定して削除をした場合には下記の結果が返ってくる

```
{
  "data": {
    "deleteJournal": null
  },
  "errors": [
    {
      "message": "Couldn't find Journal with 'id'=1",
      "locations": [
        {
          "line": 53,
          "column": 3
        }
      ],
      "path": [
        "deleteJournal"
      ]
    }
  ]
}
```


