### PR TITLE
fix #30 wsへ毎回アクセスしてしまうバグの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ flowchart TB
 
 原因はまだわかっていないようです。以下のコマンドを実行してください。
 
-`echo "WDS_SOCKET_PORT=0" >> diary/frontend/.env`
+`echo "WDS_SOCKET_PORT=0" >> frontend/.env`
 

--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ flowchart TB
 		style HerokuAddOn fill:#CFA7CD,stroke:#000000,stroke-width:4px
 		style MySQL fill:#A3BCE2,stroke:#000000,stroke-width:4px
 ```
+
+### ActionController::RoutingError (No route matches [GET] "/ws"): のエラーが気になる場合
+
+原因はまだわかっていないようです。以下のコマンドを実行してください。
+
+`echo "WDS_SOCKET_PORT=0" >> diary/frontend/.env`
+

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env


### PR DESCRIPTION
Fix: https://github.com/yuki-snow1823/diary/issues/30

railsでなぜか下記のエラーが出る

```
api_1    | Started GET "/ws" for 172.19.0.1 at 2023-06-17 09:49:24 +0900
api_1    |   
api_1    | ActionController::RoutingError (No route matches [GET] "/ws"):
```

シンオクさんのコメントを見ると、frontendのディレクトリに.envを作成し`WDS_SOCKET_PORT=0`を書くと直るとのこと。
実際に試したら直った。

このPRでは、.envを追加するわけにもいかないのでignoreの追加とREADMEの追加だけをします。

https://github.com/yuki-snow1823/diary/issues/30#issuecomment-1537336960