### PR TITLE
記事の更新機能を作成した

### DIFF
--- a/backend/app/graphql/mutations/update_journal.rb
+++ b/backend/app/graphql/mutations/update_journal.rb
@@ -1,0 +1,22 @@
+module Mutations
+    class UpdateJournal < Mutations::BaseMutation
+      field :journal, Types::JournalType, null: false
+      description "特定のJournalの更新"
+
+      argument :journal_id, Integer, required: true
+      argument :title, String, required: true
+      argument :content, String, required: true
+
+      def resolve(journal_id:, title:, content:)
+        journal = Journal.find(journal_id)
+        journal.update!({
+          title:,
+          content:,
+        })
+
+        {
+          journal: journal
+        }
+      end
+    end
+  end

--- a/backend/app/graphql/types/mutation_type.rb
+++ b/backend/app/graphql/types/mutation_type.rb
@@ -1,6 +1,7 @@
 module Types
   class MutationType < Types::BaseObject
     field :create_journal, mutation: Mutations::CreateJournal
+    field :update_journal, mutation: Mutations::UpdateJournal
     field :delete_journal, mutation: Mutations::DeleteJournal
   end
 end


### PR DESCRIPTION
## やったこと

既に実装されている[createJournal](https://github.com/yuki-snow1823/diary/pull/17)で作成された記事をidを指定して更新することができるupdateJournalを実装した

エラーハンドリングはGraphQL::ExecutionErrorに全て任せている

## やらないこと

GraphQL::ExecutionError以外でのエラーハンドリング

## 動作確認

### 前提条件

id=1 のuser が作成されていること（ターミナルにて下記のコマンドで作成可能）

```
curl -X POST http://localhost:3000/auth -d '[name]=test&[email]=test2@example.com&[password]=password&[password_confirmation]=password'
```

ここより下記の手順は
http://localhost:3000/graphiql
にて確認する

### 正常動作

#### 手順1：記事確認

queryにて記事が作成されていることを確認する

```
query{
  journals {
    id
  }
}
```

#### 手順３：記事更新

updateJournalにて記事を更新する

```
mutation{
  updateJournal(input: {
    journalId: 既存Journalのidを指定,
    title: "testtest", 
    content: "testtest",
  }) {
    journal {
      id
      title
      content
    }
  }
}
```

#### 手順3：記事確認

手順1と同様のqueryを再度叩き、手順2で実行したJournalの更新がされているか確認する

```
query{
  journals {
    id
  }
}
```


