### PR TITLE
graphqlのmutationに対するspecを追加

### DIFF
--- a/backend/spec/requests/journal/create_journal_spec.rb
+++ b/backend/spec/requests/journal/create_journal_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::CreateJournal, type: :request do
+  let(:mutation) { Mutations::CreateJournal.new(object: nil, field: nil, context: {}) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:title) { 'test_title' }
+  let(:content) { 'test_content' }
+
+  context 'ユーザーに紐付く' do
+    context '紐付いているユーザーが正しい' do
+      it 'journalが作成される' do
+        result = mutation.resolve(title:, content:, user_id: user.id)
+        journal = Journal.find(result[:journal].id)
+        expect(journal.title).to eq(title)
+        expect(journal.content).to eq(content)
+        expect(journal.user_id).to eq(user.id)
+      end
+
+      it 'titleが存在しない時はjournalが作成されない' do
+        expect do
+          mutation.resolve(title: nil, content:, user_id: user.id)
+        end.to raise_error(ActiveRecord::RecordInvalid) { |e|
+          expect(e.record.errors.full_messages).to include("Title can't be blank")
+        }
+      end
+
+      it 'contentが存在しない時はjournalが作成されない' do
+        expect do
+          mutation.resolve(title:, content: nil, user_id: user.id)
+        end.to raise_error(ActiveRecord::RecordInvalid) { |e|
+          expect(e.record.errors.full_messages).to include('Content is reserved')
+        }
+      end
+    end
+
+    context '紐付けようとしているユーザーが存在しない' do
+      it 'journalが作成されない' do
+        not_exist_user_id = User.last.id + 1
+        expect do
+          mutation.resolve(title:, content:, user_id: not_exist_user_id)
+        end.to raise_error(ActiveRecord::RecordInvalid) { |e|
+          expect(e.record.errors.full_messages).to include('User must exist')
+        }
+      end
+    end
+  end
+
+  context 'ユーザーに紐付かない' do
+    it 'journalが作成されない' do
+      expect do
+        mutation.resolve(title:, content:, user_id: nil)
+      end.to raise_error(ActiveRecord::RecordInvalid) { |e|
+        expect(e.record.errors.full_messages).to include('User must exist')
+      }
+    end
+  end
+end

--- a/backend/spec/requests/journal/delete_journal_spec.rb
+++ b/backend/spec/requests/journal/delete_journal_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::DeleteJournal, type: :request do
+  let(:mutation) { Mutations::DeleteJournal.new(object: nil, field: nil, context: {}) }
+  let(:user) { FactoryBot.create(:user) }
+  let!(:journal) { FactoryBot.create(:journal, user_id: user.id) }
+
+  before do
+    @journals = Journal.all
+  end
+
+  context '存在するjournalを削除をしようとする場合' do
+    it 'journalが削除される' do
+      expect do
+        mutation.resolve(journal_id: journal.id)
+      end.to change(@journals, :count).by(-1)
+    end
+  end
+
+  context '存在しないjournalを削除をしようとする場合' do
+    it 'journalが削除されない' do
+      not_exist_journal_id = @journals.last.id + 1
+      expect do
+        mutation.resolve(journal_id: not_exist_journal_id)
+      end.to_not change(@journals, :count)
+    end
+  end
+end

--- a/backend/spec/requests/journal/update_journal_spec.rb
+++ b/backend/spec/requests/journal/update_journal_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::UpdateJournal, type: :request do
+  let(:mutation) { Mutations::UpdateJournal.new(object: nil, field: nil, context: {}) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:journal) { FactoryBot.create(:journal, user_id: user.id) }
+  let(:title) { 'test_title' }
+  let(:content) { 'test_content' }
+
+  context '存在するjournalを更新をしようとする場合' do
+    context '正常系' do
+      it 'journalが更新される' do
+        result = mutation.resolve(journal_id: journal.id, title:, content:)
+        journal = Journal.find(result[:journal].id)
+        expect(journal.title).to eq(title)
+        expect(journal.content).to eq(content)
+        expect(journal.user_id).to eq(user.id)
+      end
+    end
+
+    context '異常系' do
+      it 'titleが存在しない時はjournalが更新されない' do
+        expect do
+          mutation.resolve(journal_id: journal.id, title: nil, content:)
+        end.to raise_error(ActiveRecord::RecordInvalid) { |e|
+          expect(e.record.errors.full_messages).to include("Title can't be blank")
+        }
+      end
+
+      it 'contentが存在しない時はjournalが更新されない' do
+        expect do
+          mutation.resolve(journal_id: journal.id, title:, content: nil)
+        end.to raise_error(ActiveRecord::RecordInvalid) { |e|
+          expect(e.record.errors.full_messages).to include('Content is reserved')
+        }
+      end
+    end
+  end
+
+  context '存在しないjournalを更新をしようとする場合' do
+    it 'エラーが検知される' do
+      not_exist_journal_id = Journal.last.id + 1
+      expect do
+        mutation.resolve(journal_id: not_exist_journal_id, title:, content:)
+      end.to raise_error(ActiveRecord::RecordNotFound) { |e|
+        expect(e.message).to include("Couldn't find Journal with 'id'=#{not_exist_journal_id}")
+      }
+    end
+  end
+end


### PR DESCRIPTION
# やったこと

```
backend/app/graphql/mutations/create_journal.rb
backend/app/graphql/mutations/delete_journal.rb
backend/app/graphql/mutations/update_journal.rb
```

に対応するrequest spec

```
backend/spec/requests/journal/create_journal_spec.rb
backend/spec/requests/journal/delete_journal_spec.rb
backend/spec/requests/journal/update_journal_spec.rb
```

をそれぞれ新規に追加した。

# やらないこと

- アプリケーションの挙動が変わるような修正
- 認可・認証に対応したテストケースの用意（まだ処理自体が実装されていないので）

# 動作確認

apiコンテナに`docker compose exec api bash`などで入った後に
`rspec`や`rspec spec/requests/journal`などのコマンドでローカル環境でrspecを実行して確認
なし