### PR TITLE
JournalモデルのバリデーションをDBと合わせる

### DIFF
--- a/backend/app/models/journal.rb
+++ b/backend/app/models/journal.rb
@@ -1,4 +1,5 @@
 class Journal < ApplicationRecord
-  validates :title, length: { minimum: 2 }
+  validates :title, presence: true, length: { minimum: 2 }
+  validates :content, exclusion: { in: [nil] }
   belongs_to :user
 end

--- a/backend/spec/models/journal_spec.rb
+++ b/backend/spec/models/journal_spec.rb
@@ -2,11 +2,21 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe Journal do
-  describe 'バリデーションのテスト' do
+  context 'バリデーションの正常系テスト' do
     it '2文字のタイトルは保存される' do
       expect(build(:journal, title: 'tt')).to be_valid
     end
 
+    it '1文字の内容は保存される' do
+      expect(build(:journal, content: 'c')).to be_valid
+    end
+
+    it '空文字の内容は保存される' do
+      expect(build(:journal, content: '')).to be_valid
+    end
+  end
+
+  context 'バリデーションの異常系テスト' do
     it '1文字のタイトルは保存されない' do
       expect(build(:journal, title: 't')).to be_invalid
     end
@@ -17,14 +27,6 @@ describe Journal do
 
     it 'タイトルがnilの場合は保存されない' do
       expect(build(:journal, title: nil)).to be_invalid
-    end
-
-    it '1文字の内容は保存される' do
-      expect(build(:journal, content: 'c')).to be_valid
-    end
-
-    it '空文字の内容は保存される' do
-      expect(build(:journal, content: '')).to be_valid
     end
 
     it '内容がnilの場合は保存されない' do

--- a/backend/spec/models/journal_spec.rb
+++ b/backend/spec/models/journal_spec.rb
@@ -3,12 +3,28 @@ require 'spec_helper'
 
 describe Journal do
   describe 'バリデーションのテスト' do
+    it '2文字のタイトルは保存される' do
+      expect(build(:journal, title: 'tt')).to be_valid
+    end
+
     it '1文字のタイトルは保存されない' do
       expect(build(:journal, title: 't')).to be_invalid
     end
 
+    it '空文字のタイトルは保存されない' do
+      expect(build(:journal, title: '')).to be_invalid
+    end
+
     it 'タイトルがnilの場合は保存されない' do
       expect(build(:journal, title: nil)).to be_invalid
+    end
+
+    it '1文字の内容は保存される' do
+      expect(build(:journal, content: 'c')).to be_valid
+    end
+
+    it '空文字の内容は保存される' do
+      expect(build(:journal, content: '')).to be_valid
     end
 
     it '内容がnilの場合は保存されない' do

--- a/backend/spec/models/journal_spec.rb
+++ b/backend/spec/models/journal_spec.rb
@@ -6,5 +6,13 @@ describe Journal do
     it '1文字のタイトルは保存されない' do
       expect(build(:journal, title: 't')).to be_invalid
     end
+
+    it 'タイトルがnilの場合は保存されない' do
+      expect(build(:journal, title: nil)).to be_invalid
+    end
+
+    it '内容がnilの場合は保存されない' do
+      expect(build(:journal, content: nil)).to be_invalid
+    end
   end
 end


### PR DESCRIPTION
## やったこと

現状の[Journalモデル](https://github.com/yuki-snow1823/diary/blob/main/backend/app/models/journal.rb#L2)のバリデーションの記載だと、アプリケーションでエラー検知せずにDB側でエラーを検知する場合（[contentがnil](https://github.com/yuki-snow1823/diary/blob/main/backend/db/migrate/20230325142341_change_columns_null_false_on_journalsbundle.rb#L5C4-L5C4)）があるため、モデル側のバリデーションを追記

## 動作確認

RSpecを追加した
