### PR TITLE
create_journalにrequiered trueの記述を追

### DIFF
--- a/backend/app/graphql/mutations/create_journal.rb
+++ b/backend/app/graphql/mutations/create_journal.rb
@@ -2,8 +2,8 @@ module Mutations
   class CreateJournal < Mutations::BaseMutation
     field :journal, Types::JournalType, null: false
 
-    argument :title, String
-    argument :content, String
+    argument :title, String, required: true
+    argument :content, String, required: true
     argument :user_id, Integer, required: true
 
     def resolve(title:, content:, user_id:)

--- a/backend/app/models/journal.rb
+++ b/backend/app/models/journal.rb
@@ -1,4 +1,5 @@
 class Journal < ApplicationRecord
-  validates :title, length: { minimum: 2 }
+  validates :title, presence: true, length: { minimum: 2 }
+  validates :content, exclusion: { in: [nil] }
   belongs_to :user
 end

--- a/backend/spec/models/journal_spec.rb
+++ b/backend/spec/models/journal_spec.rb
@@ -6,5 +6,13 @@ describe Journal do
     it '1文字のタイトルは保存されない' do
       expect(build(:journal, title: 't')).to be_invalid
     end
+
+    it 'タイトルがnilの場合は保存されない' do
+      expect(build(:journal, title: nil)).to be_invalid
+    end
+
+    it '内容がnilの場合は保存されない' do
+      expect(build(:journal, content: nil)).to be_invalid
+    end
   end
 end


### PR DESCRIPTION
# やったこと

[update_journal](https://github.com/yuki-snow1823/diary/blob/main/backend/app/graphql/mutations/update_journal.rb#L7)の方には

```ruby
argument :title, String, required: true
argument :content, String, required: true
```

という記載になっているのでcreate_journalの方も合わせた方が良いかなと思ったため修正

# やらないこと

アプリケーションの挙動が変わるような修正

# 動作確認

http://localhost:3000/graphiql
において下記の形でmutationを実行し

【titleなしの場合】

```
mutation{
  createJournal(input: {
    content: "xxxxxxxxx",
    userId: 1,
  }) {
    journal {
      id
    }
    }
}
```
【contentなしの場合】

```
mutation{
  createJournal(input: {
   title: "xxxxxxxxx",
    userId: 1,
  }) {
    journal {
      id
    }
    }
}
```

titleなしの場合に`Argument 'title' on InputObject 'CreateJournalInput' is required. Expected type String!`というエラーメッセージ
contentなしの場合`Argument 'content' on InputObject 'CreateJournalInput' is required. Expected type String!`というエラーメッセージ
がそれぞれ確認できること

※ 「やらないこと」にもある通り、「アプリケーションの挙動が変わるような修正」ではないので上記の挙動はこのPRによってはじめて実現できたものというわけではないです！（mainブランチでも同じ挙動になります）



