### PR TITLE
create_journalにrequieredの記述を追加

### DIFF
--- a/backend/app/graphql/mutations/create_journal.rb
+++ b/backend/app/graphql/mutations/create_journal.rb
@@ -2,8 +2,8 @@ module Mutations
   class CreateJournal < Mutations::BaseMutation
     field :journal, Types::JournalType, null: false
 
-    argument :title, String
-    argument :content, String
+    argument :title, String, required: true
+    argument :content, String, required: true
     argument :user_id, Integer, required: true
 
     def resolve(title:, content:, user_id:)


### PR DESCRIPTION
# やったこと

[update_journal]([https://github.com/yuki-snow1823/diary/blob/main/backend/app/graphql/mutations/update_journal.rb#L7)の方には](https://github.com/yuki-snow1823/diary/blob/main/backend/app/graphql/mutations/update_journal.rb#L7)%E3%81%AE%E6%96%B9%E3%81%AB%E3%81%AF)

```ruby
argument :title, String, required: true
argument :content, String, required: true
```

という記載になっているのでcreate_journalの方も合わせた方が良いかなと思ったため修正

# やらないこと

アプリケーションの挙動が変わるような修正

# 動作確認

http://localhost:3000/graphiql
において下記の形でmutationを実行し

【titleなしの場合】

```
mutation{
  createJournal(input: {
    content: "xxxxxxxxx",
    userId: 1,
  }) {
    journal {
      id
    }
    }
}
```
【contentなしの場合】

```
mutation{
  createJournal(input: {
   title: "xxxxxxxxx",
    userId: 1,
  }) {
    journal {
      id
    }
    }
}
```

titleなしの場合に`Argument 'title' on InputObject 'CreateJournalInput' is required. Expected type String!`というエラーメッセージ
contentなしの場合`Argument 'content' on InputObject 'CreateJournalInput' is required. Expected type String!`というエラーメッセージ
がそれぞれ確認できること

※ 「やらないこと」にもある通り、「アプリケーションの挙動が変わるような修正」ではないので上記の挙動はこのPRによってはじめて実現できたものというわけではないです！（mainブランチでも同じ挙動になります）