### PR TITLE
Block has too many linesはrspecでは無視したい

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -17,3 +17,6 @@ MethodLength:
   Max: 24
 Naming/MethodParameterName:
   Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'


### PR DESCRIPTION
# やったこと

`backend/.rubocop.yml`にRSpec のコードでは Rubocop の "Block has too many lines." という警告を無視するように追記した。

# やらないこと

アプリケーションの挙動が変わるような修正

# 動作確認

なし