### PR TITLE
mutations_rspec実装(execute方式)

### DIFF
--- a/backend/app/graphql/mutations/update_journal.rb
+++ b/backend/app/graphql/mutations/update_journal.rb
@@ -17,6 +17,8 @@ module Mutations
       {
         journal:
       }
+    rescue ActiveRecord::RecordNotFound => e
+      raise GraphQL::ExecutionError.new(e, extensions: { code: 'RECORD_NOT_FOUND' })
     end
   end
 end

--- a/backend/app/graphql/mutations/update_journal.rb
+++ b/backend/app/graphql/mutations/update_journal.rb
@@ -1,22 +1,22 @@
 module Mutations
-    class UpdateJournal < Mutations::BaseMutation
-      field :journal, Types::JournalType, null: false
-      description "特定のJournalの更新"
+  class UpdateJournal < Mutations::BaseMutation
+    field :journal, Types::JournalType, null: false
+    description '特定のJournalの更新'
 
-      argument :journal_id, Integer, required: true
-      argument :title, String, required: true
-      argument :content, String, required: true
+    argument :journal_id, Integer, required: true
+    argument :title, String, required: true
+    argument :content, String, required: true
 
-      def resolve(journal_id:, title:, content:)
-        journal = Journal.find(journal_id)
-        journal.update!({
-          title:,
-          content:,
-        })
+    def resolve(journal_id:, title:, content:)
+      journal = Journal.find(journal_id)
+      journal.update!({
+                        title:,
+                        content:
+                      })
 
-        {
-          journal: journal
-        }
-      end
+      {
+        journal:
+      }
     end
   end
+end

--- a/backend/spec/graphql/mutations/create_journal_spec.rb
+++ b/backend/spec/graphql/mutations/create_journal_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Mutations::CreateJournal do
 
   let(:title) { 'test_title' }
   let(:content) { 'test_content' }
-  let(:user_id) { user.id } 
+  let(:user_id) { user.id }
 
   let(:result) do
     BackendSchema.execute(

--- a/backend/spec/graphql/mutations/create_journal_spec.rb
+++ b/backend/spec/graphql/mutations/create_journal_spec.rb
@@ -3,91 +3,39 @@ require 'rails_helper'
 RSpec.describe Mutations::CreateJournal do
   let(:user) { create(:user) }
 
-  it 'title, content, user_idが全て入力されたときjournalが作成できる' do
-    expect do
-      @result = BackendSchema.execute(create_journal_mutation,
-                                      variables: {
-                                        title: 'test_tile',
-                                        content: 'test_content',
-                                        userId: user.id
-                                      }).as_json
-    end.to change(Journal, :count).by(1)
-
-    journal = Journal.find(@result.dig('data', 'createJournal', 'journal', 'id'))
-    expect(journal).to have_attributes(title: 'test_tile', content: 'test_content', user_id: user.id)
-  end
-
-  it 'titleがnilのときjournalが作成されずエラーが発生する' do
-    expect do
-      @result = BackendSchema.execute(create_journal_mutation,
-                                      variables: {
-                                        title: nil,
-                                        content: 'test_content',
-                                        userId: user.id
-                                      }).as_json
-    end.to_not change(Journal, :count)
-
-    expect(@result.dig('data', 'createJournal', 'journal')).to be_nil
-    expect(@result['errors']).to be_truthy
-  end
-
-  it 'contentがnilのときjournalが作成されずエラーが発生する' do
-    expect do
-      @result = BackendSchema.execute(create_journal_mutation,
-                                      variables: {
-                                        title: 'test_tile',
-                                        content: nil,
-                                        userId: user.id
-                                      }).as_json
-    end.to_not change(Journal, :count)
-
-    expect(@result.dig('data', 'createJournal', 'journal')).to be_nil
-    expect(@result['errors']).to be_truthy
-  end
-
-  it 'userIdがnilのときjournalが作成されずエラーが発生する' do
-    expect do
-      @result = BackendSchema.execute(create_journal_mutation,
-                                      variables: {
-                                        title: 'test_tile',
-                                        content: 'test_content',
-                                        userId: nil
-                                      }).as_json
-    end.to_not change(Journal, :count)
-
-    expect(@result.dig('data', 'createJournal', 'journal')).to be_nil
-    expect(@result['errors']).to be_truthy
-  end
-
-  it 'userIdにDBに存在しない値が指定された時にjournalが作成されずエラーが発生する' do
-    not_exist_user_id = User.last.id + 1
-    # testを通すためにこの書き方にしているが、そもそもの実装の方を変えた方が良いかもしれない
-    expect do
-      BackendSchema.execute(create_journal_mutation,
-                            variables: {
-                              title: 'test_tile',
-                              content: 'test_content',
-                              userId: not_exist_user_id
-                            }).as_json
-    end.to raise_error(ActiveRecord::RecordInvalid)
-  end
-
-  def create_journal_mutation
-    <<~GRAPHQL
-      mutation createJournal($title: String!, $content: String!, $userId: Int!) {
-        createJournal(input: {
-          title: $title,
-          content: $content,
-          userId: $userId,
-        }) {
-          journal {
-            id
-            title
-            content
-            userId
-          }
+  let(:mutation) { <<~MUTATION }
+    mutation ($title: String!, $content: String!, $userId: Int!) {
+      createJournal(input: { title: $title, content: $content, userId: $userId }) {
+        journal {
+          id
+          title
+          content
+          userId
         }
       }
-    GRAPHQL
+    }
+  MUTATION
+
+  let(:title) { 'test_title' }
+  let(:content) { 'test_content' }
+  let(:user_id) { user.id } 
+
+  let(:result) do
+    BackendSchema.execute(
+      mutation,
+      variables: {
+        title: title,
+        content: content,
+        userId: user_id
+      }
+    )
+  end
+
+  # TODO: 本当はcontextログイン時などを設定したい
+  it 'title, content, user_idが全て入力されたときjournalが作成できる' do
+    expect { result }.to change { Journal.count }.by(1)
+    expect(result.dig('data', 'createJournal', 'journal', 'userId')).to eq(user_id)
+    expect(result.dig('data', 'createJournal', 'journal', 'title')).to eq(title)
+    expect(result.dig('data', 'createJournal', 'journal', 'content')).to eq(content)
   end
 end

--- a/backend/spec/graphql/mutations/create_journal_spec.rb
+++ b/backend/spec/graphql/mutations/create_journal_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::CreateJournal do
+  let(:user) { create(:user) }
+
+  it 'title, content, user_idが全て入力されたときjournalが作成できる' do
+    expect do
+      @result = BackendSchema.execute(create_journal_mutation,
+                                      variables: {
+                                        title: 'test_tile',
+                                        content: 'test_content',
+                                        userId: user.id
+                                      }).as_json
+    end.to change(Journal, :count).by(1)
+
+    journal = Journal.find(@result.dig('data', 'createJournal', 'journal', 'id'))
+    expect(journal).to have_attributes(title: 'test_tile', content: 'test_content', user_id: user.id)
+  end
+
+  it 'titleがnilのときjournalが作成されずエラーが発生する' do
+    expect do
+      @result = BackendSchema.execute(create_journal_mutation,
+                                      variables: {
+                                        title: nil,
+                                        content: 'test_content',
+                                        userId: user.id
+                                      }).as_json
+    end.to_not change(Journal, :count)
+
+    expect(@result.dig('data', 'createJournal', 'journal')).to be_nil
+    expect(@result['errors']).to be_truthy
+  end
+
+  it 'contentがnilのときjournalが作成されずエラーが発生する' do
+    expect do
+      @result = BackendSchema.execute(create_journal_mutation,
+                                      variables: {
+                                        title: 'test_tile',
+                                        content: nil,
+                                        userId: user.id
+                                      }).as_json
+    end.to_not change(Journal, :count)
+
+    expect(@result.dig('data', 'createJournal', 'journal')).to be_nil
+    expect(@result['errors']).to be_truthy
+  end
+
+  it 'userIdがnilのときjournalが作成されずエラーが発生する' do
+    expect do
+      @result = BackendSchema.execute(create_journal_mutation,
+                                      variables: {
+                                        title: 'test_tile',
+                                        content: 'test_content',
+                                        userId: nil
+                                      }).as_json
+    end.to_not change(Journal, :count)
+
+    expect(@result.dig('data', 'createJournal', 'journal')).to be_nil
+    expect(@result['errors']).to be_truthy
+  end
+
+  it 'userIdにDBに存在しない値が指定された時にjournalが作成されずエラーが発生する' do
+    not_exist_user_id = User.last.id + 1
+    # testを通すためにこの書き方にしているが、そもそもの実装の方を変えた方が良いかもしれない
+    expect do
+      BackendSchema.execute(create_journal_mutation,
+                            variables: {
+                              title: 'test_tile',
+                              content: 'test_content',
+                              userId: not_exist_user_id
+                            }).as_json
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  def create_journal_mutation
+    <<~GRAPHQL
+      mutation createJournal($title: String!, $content: String!, $userId: Int!) {
+        createJournal(input: {
+          title: $title,
+          content: $content,
+          userId: $userId,
+        }) {
+          journal {
+            id
+            title
+            content
+            userId
+          }
+        }
+      }
+    GRAPHQL
+  end
+end

--- a/backend/spec/graphql/mutations/create_journal_spec.rb
+++ b/backend/spec/graphql/mutations/create_journal_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Mutations::CreateJournal do
     BackendSchema.execute(
       mutation,
       variables: {
-        title: title,
-        content: content,
+        title:,
+        content:,
         userId: user_id
       }
     )

--- a/backend/spec/graphql/mutations/delete_journal_spec.rb
+++ b/backend/spec/graphql/mutations/delete_journal_spec.rb
@@ -4,48 +4,32 @@ RSpec.describe Mutations::DeleteJournal do
   let(:user) { create(:user) }
   let!(:journal) { create(:journal, user:) }
 
-  it '存在するjournalIdが入力されたときjournalが削除できる' do
-    expect do
-      BackendSchema.execute(delete_journal_mutation,
-                            variables: {
-                              journalId: journal.id
-                            })
-    end.to change(Journal, :count).by(-1)
-  end
-
-  it '存在しないjournalIdが入力されたときjournalが削除されない' do
-    not_exist_journal_id = Journal.last.id + 1
-    expect do
-      BackendSchema.execute(delete_journal_mutation,
-                            variables: {
-                              journalId: not_exist_journal_id
-                            })
-    end.to_not change(Journal, :count)
-  end
-
-  it 'journalIdがnilのときjournalが削除されない' do
-    expect do
-      BackendSchema.execute(delete_journal_mutation,
-                            variables: {
-                              journalId: nil
-                            })
-    end.to_not change(Journal, :count)
-  end
-
-  def delete_journal_mutation
-    <<~GRAPHQL
-      mutation deleteJournal($journalId: Int!) {
-        deleteJournal(input: {
-          journalId: $journalId,
-        }) {
-          journal {
-            id
-            title
-            content
-            userId
-          }
+  let(:mutation) { <<~MUTATION }
+    mutation ($journalId: Int!) {
+      deleteJournal(input: { journalId: $journalId }) {
+        journal {
+          id
+          title
+          content
+          userId
         }
       }
-    GRAPHQL
+    }
+  MUTATION
+
+  let(:journal_id) { journal.id }
+
+  let(:result) do
+    BackendSchema.execute(
+      mutation,
+      variables: {
+        journalId: journal_id
+      }
+    )
+  end
+
+  # TODO: 本当はcontextログイン時などを設定したい
+  it '存在するjournalIdが入力されたときjournalが削除できる' do
+    expect { result }.to change { Journal.count }.by(-1)
   end
 end

--- a/backend/spec/graphql/mutations/delete_journal_spec.rb
+++ b/backend/spec/graphql/mutations/delete_journal_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::DeleteJournal do
+  let(:user) { create(:user) }
+  let!(:journal) { create(:journal, user:) }
+
+  it '存在するjournalIdが入力されたときjournalが削除できる' do
+    expect do
+      BackendSchema.execute(delete_journal_mutation,
+                            variables: {
+                              journalId: journal.id
+                            })
+    end.to change(Journal, :count).by(-1)
+  end
+
+  it '存在しないjournalIdが入力されたときjournalが削除されない' do
+    not_exist_journal_id = Journal.last.id + 1
+    expect do
+      BackendSchema.execute(delete_journal_mutation,
+                            variables: {
+                              journalId: not_exist_journal_id
+                            })
+    end.to_not change(Journal, :count)
+  end
+
+  it 'journalIdがnilのときjournalが削除されない' do
+    expect do
+      BackendSchema.execute(delete_journal_mutation,
+                            variables: {
+                              journalId: nil
+                            })
+    end.to_not change(Journal, :count)
+  end
+
+  def delete_journal_mutation
+    <<~GRAPHQL
+      mutation deleteJournal($journalId: Int!) {
+        deleteJournal(input: {
+          journalId: $journalId,
+        }) {
+          journal {
+            id
+            title
+            content
+            userId
+          }
+        }
+      }
+    GRAPHQL
+  end
+end

--- a/backend/spec/graphql/mutations/update_journal_spec.rb
+++ b/backend/spec/graphql/mutations/update_journal_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::UpdateJournal do
+  let(:user) { create(:user) }
+  let(:journal) { create(:journal, user:) }
+
+  it 'journal_id, title, contentが全て入力されたときjournalが更新できる' do
+    @result = BackendSchema.execute(update_journal_mutation,
+                                    variables: {
+                                      journalId: journal.id,
+                                      title: 'update_tile',
+                                      content: 'update_content'
+                                    }).as_json
+
+    journal = Journal.find(@result.dig('data', 'updateJournal', 'journal', 'id'))
+    expect(journal).to have_attributes(title: 'update_tile', content: 'update_content')
+  end
+
+  it 'titleがnilのときjournalが更新されずエラーが発生する' do
+    @result = BackendSchema.execute(update_journal_mutation,
+                                    variables: {
+                                      journalId: journal.id,
+                                      title: nil,
+                                      content: 'update_content'
+                                    }).as_json
+
+    expect(@result.dig('data', 'updateJournal', 'journal')).to be_nil
+    expect(@result['errors']).to be_truthy
+  end
+
+  it 'contentが空のときjournalが作成されずエラーが発生する' do
+    @result = BackendSchema.execute(update_journal_mutation,
+                                    variables: {
+                                      journalId: journal.id,
+                                      title: 'update_tile',
+                                      content: nil
+                                    }).as_json
+
+    expect(@result.dig('data', 'updateJournal', 'journal')).to be_nil
+    expect(@result['errors']).to be_truthy
+  end
+
+  it 'journalIdが空のときjournalが作成されずエラーが発生する' do
+    @result = BackendSchema.execute(update_journal_mutation,
+                                    variables: {
+                                      journalId: nil,
+                                      title: 'update_tile',
+                                      content: 'update_content'
+                                    }).as_json
+
+    expect(@result.dig('data', 'updateJournal', 'journal')).to be_nil
+    expect(@result['errors']).to be_truthy
+  end
+
+  it 'journalIdにDBに存在しない値が指定された時にjournalが作成されずエラーが発生する' do
+    not_exist_journal_id = Journal.last.id + 1
+    # testを通すためにこの書き方にしているが、そもそもの実装の方を変えた方が良いかもしれない
+    expect do
+      BackendSchema.execute(update_journal_mutation,
+                            variables: {
+                              journalId: not_exist_journal_id,
+                              title: 'update_tile',
+                              content: 'update_content'
+                            })
+    end.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  def update_journal_mutation
+    <<~GRAPHQL
+      mutation updateJournal($journalId: Int!, $title: String!, $content: String!) {
+        updateJournal(input: {
+          journalId: $journalId,
+          title: $title,
+          content: $content,
+        }) {
+          journal {
+            id
+            title
+            content
+            userId
+          }
+        }
+      }
+    GRAPHQL
+  end
+end


### PR DESCRIPTION
# やったこと

```
backend/app/graphql/mutations/create_journal.rb
backend/app/graphql/mutations/delete_journal.rb
backend/app/graphql/mutations/update_journal.rb
```

に対応するrequest spec

```
backend/spec/graphql/mutations/create_journal_spec.rb
backend/spec/graphql/mutations/delete_journal_spec.rb
backend/spec/graphql/mutations/update_journal_spec.rb
```

をそれぞれ新規に追加した。

また、その際にupdate_journal_specにおいてjournalのidがDBに存在しないパターンをテストしようと思うと、先に`ActiveRecord::RecordNotFound`が検知されてしまいgraphqlまで到達しないので例外処理を追加した

# やらないこと

- アプリケーションの挙動が変わるような修正
- 認可・認証に対応したテストケースの用意（まだ処理自体が実装されていないので）

# 動作確認

apiコンテナに`docker compose exec api bash`などで入った後に
`rspec`や`rspec spec/requests/journal`などのコマンドでローカル環境でrspecを実行して確認
なし

# 特に見てほしい部分

- `backend/app/graphql/mutations/update_journal.rb`の例外処理の実装はこの方針で良いか
- `backend/spec/graphql/mutations/update_journal_spec.rb`において`let(:result)`の部分で `journalId`を引数として渡すためにlamdaメソッドで書いていることでresultを呼び出すときに毎回callする必要が出てしまったが実装方針として問題ないか

# その他

レビューにあたっては [Rails x RSpec x GraphQLでの単体テストの最適解を考えたいスレッド](https://github.com/yuki-snow1823/diary/discussions/50) の内容を把握してもらえると大変助かります！

7月23日(日)13:00~ のオフライン会までコードをいじる時間が取れないので、もし後続の作業で必要であれば、このPRへの追加コミットとかマージ作業とかはお任せできると助かります！

