### PR TITLE
yarnをdockerコンテナではなくホストマシン上で実行するようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Diary
 
 ## 開発環境の構築方法
 
-`docker-compose up`で起動できるようになっています。
+`docker-compose up`でバックエンドのAPIを起動することができます。
+その後、frontendのディレクトリで`yarn install && yarn start`を実行してください。
 
 ## 使用方法
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,14 +26,5 @@ services:
     depends_on:
       - db
 
-  front:
-    image: node:19.3.0-alpine3.17
-    volumes:
-      - ./frontend:/usr/src/app
-    working_dir: /usr/src/app
-    command: sh -c "yarn && yarn start"
-    ports:
-      - "8080:3000"
-
 volumes:
   mysql-data:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=8080 react-scripts start",
     "build": "react-scripts build && echo '/* /index.html  200' | cat >build/_redirects ",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
## 何を解決するのか
Dockerコンテナ上でyarnを動かすと動作が重かったり、パッケージをインストールした時にビルドし直すなど不都合が多かったので、一旦ホストマシン上で動かすようにします。

いずれプロジェクトの起動コマンドをまとめたいですね。

初回のyarnに関しての起動時間が10分くらいから30秒になりました。