### PR TITLE
wait-for-itを初回の起動時だけ実行する

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,8 +7,7 @@ COPY . .
 
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh"]
 
 EXPOSE 3000
 
-CMD ["rails", "server", "-b", "0.0.0.0"]
+CMD ["bash", "-c", "/usr/bin/entrypoint.sh && rails server -b 0.0.0.0"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -14,7 +14,6 @@ COPY . $APP_PATH
 
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3000
 
-CMD ["rails", "server", "-b", "0.0.0.0"]
+CMD ["bash", "-c", "/usr/bin/entrypoint.sh && rails server -b 0.0.0.0"]


### PR DESCRIPTION
## 何を解決するのか
これまでだと、enteypoint.shの中でwait-for-itを呼び出しており、それがDockerfileでENYRYPOINTと指定されていたので、コンテナを作る際に毎回実行されるような形になっていた。そこで、初回の起動時だけ行われるようにしました。