### PR TITLE
RSpecでtest用DBを使う

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -39,14 +39,13 @@ gem "rack-cors"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'rspec-rails', '~> 4.0.1', '>= 4.0.1'
+  gem 'factory_bot_rails'
 end
 
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-  gem 'rspec-rails', '~> 4.0.1', '>= 4.0.1'
-  gem 'factory_bot_rails'
-
   gem 'rubocop', require: false
   gem 'graphiql-rails'
   gem 'sass-rails'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - ./backend:/sample
     environment:
       TZ: Asia/Tokyo
-      RAILS_ENV: development
       GITHUB_ACTIONS: "${GITHUB_ACTIONS:-false}"
     ports:
       - 3000:3000


### PR DESCRIPTION
## 何を解決するのか(関連するissueへのリンク等)

RSpecのときもdevelopmentのDBを使ってしまっている、本当はtest用のDBを使いたい
https://github.com/yuki-snow1823/diary/pull/95#discussion_r1275137753

## 実装の内容や理由（コードからは読み取れない情報を書きましょう）

apiコンテナでRAILS_ENVを固定しているのが良くないと思った

## 不安なところ・レビューしてもらいたいところ

場合によっては１回コンテナ削除したりしないと上手く反映されないかもです
RSpecの適当な箇所に`User.count`とか入れて0とかが返ってくると上手くいってそう
（実装前はseedでdevelopmentのDBに10件のuserを入れているので、10って返ってきてた）
