### PR TITLE
新規登録のテストを追加

### DIFF
--- a/backend/spec/request/users/auth/registration_spec.rb
+++ b/backend/spec/request/users/auth/registration_spec.rb
@@ -31,4 +31,3 @@ RSpec.describe 'Users::Auth::Registrations', type: :request do
     end
   end
 end
-

--- a/backend/spec/request/users/auth/registration_spec.rb
+++ b/backend/spec/request/users/auth/registration_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'Users::Auth::Registrations', type: :request do
     context '登録に必要な情報がある場合' do
       it 'ユーザー登録ができる' do
         post user_registration_path, params: valid_attributes
-        expect(User.count).to eq 1
-        expect(User.first.name).to eq 'test'
+        expect { do_request }.to change(User, :count).by(1)
+        expect(User.sole).to have_attributes(name: 'test', email: 'test@example.com')
         expect(response).to have_http_status(:ok)
       end
     end

--- a/backend/spec/request/users/auth/registration_spec.rb
+++ b/backend/spec/request/users/auth/registration_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Users::Auth::Registrations', type: :request do
+  describe 'POST /users/auth/sign_up' do
+    let(:valid_attributes) do
+      {
+        name: 'test',
+        email: 'test@example.com',
+        password: 'password',
+        password_confirmation: 'password'
+      }
+    end
+
+    context '登録に必要な情報がある場合' do
+      it 'ユーザー登録ができる' do
+        post user_registration_path, params: valid_attributes
+        expect(User.count).to eq 1
+        expect(User.first.name).to eq 'test'
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '登録に必要な情報がない場合' do
+      let(:invalid_attributes) { valid_attributes.merge(email: '') }
+
+      it 'ユーザー登録ができない' do
+        post user_registration_path, params: invalid_attributes
+        expect(User.count).to eq 0
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end
+

--- a/backend/spec/request/users/auth/registration_spec.rb
+++ b/backend/spec/request/users/auth/registration_spec.rb
@@ -11,25 +11,27 @@ RSpec.describe 'Users::Auth::Registrations', type: :request do
       }
     end
 
+    let(:invalid_attributes) { valid_attributes.merge(email: '') }
+
     def do_request
-      post user_registration_path, params:
+      post user_registration_path, params: 
     end
 
-    context '登録に必要な情報がある場合' do
+    context 'メールアドレスがある場合' do
+      let(:params) { valid_attributes }
+
       it 'ユーザー登録ができる' do
-        post user_registration_path, params: valid_attributes
         expect { do_request }.to change(User, :count).by(1)
         expect(User.sole).to have_attributes(name: 'test', email: 'test@example.com')
         expect(response).to have_http_status(:ok)
       end
     end
 
-    context '登録に必要な情報がない場合' do
-      let(:invalid_attributes) { valid_attributes.merge(email: '') }
+    context 'メールアドレスが空の場合' do
+      let(:params) { invalid_attributes }
 
       it 'ユーザー登録ができない' do
-        post user_registration_path, params: invalid_attributes
-        expect(User.count).to eq 0
+        expect { do_request }.not_to change(User, :count)
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end

--- a/backend/spec/request/users/auth/registration_spec.rb
+++ b/backend/spec/request/users/auth/registration_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe 'Users::Auth::Registrations', type: :request do
       }
     end
 
+    def do_request
+      post user_registration_path, params:
+    end
+
     context '登録に必要な情報がある場合' do
       it 'ユーザー登録ができる' do
         post user_registration_path, params: valid_attributes

--- a/backend/spec/request/users/auth/registration_spec.rb
+++ b/backend/spec/request/users/auth/registration_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Users::Auth::Registrations', type: :request do
     let(:invalid_attributes) { valid_attributes.merge(email: '') }
 
     def do_request
-      post user_registration_path, params: 
+      post user_registration_path, params:
     end
 
     context 'メールアドレスがある場合' do


### PR DESCRIPTION
## 何を解決するのか(関連するissueへのリンク等)
https://github.com/yuki-snow1823/diary/issues/57

## 実装の内容や理由（コードからは読み取れない情報を書きましょう）
まずはテストを追加して動作することを確認しました。
このPRがマージされた後、フロントエンドを作成します。

## 不安なところ・レビューしてもらいたいところ
FactoryBotを使用してbuildし（その時点ではレコードを記録しない）そのnameやemailを使うという方法もあります。
[こんな感じ（spec/requests/users/auth/registrations_spec.rb を作成の箇所）](https://blog.nightonly.com/2021/08/19/%E5%B0%8E%E5%85%A5%E3%81%97%E3%81%9Fdevise-token-auth%E5%90%91%E3%81%91%E3%81%AB%E3%83%86%E3%82%B9%E3%83%88rspec%E3%82%92%E6%9B%B8%E3%81%8F/)です。

一方で、登録というのは適切な値をセットして、POSTリクエストを送る行為なので、FactoryBotのbuild云々などを極力無くしてテストしたかったため、普通にPOSTする感じにしています。