### PR TITLE
query_type_specで取得できるJournalの値が期待通りかを検証するようにした

### DIFF
--- a/backend/app/graphql/types/query_type.rb
+++ b/backend/app/graphql/types/query_type.rb
@@ -10,7 +10,7 @@ module Types
     end
 
     def journals
-      Journal.all
+      Journal.order(:id)
     end
 
     def journal(id:)

--- a/backend/spec/graphql/types/query_type_spec.rb
+++ b/backend/spec/graphql/types/query_type_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Types::QueryType do
   describe 'journals' do
-    before do
-      create_list(:journal, 3)
-    end
+    let!(:journal1) { create(:journal, title: 'タイトル1', content: '内容1') }
+    let!(:journal2) { create(:journal, title: 'タイトル2', content: '内容2') }
+    let!(:journal3) { create(:journal, title: 'タイトル3', content: '内容3') }
 
     let(:query) do
       <<~QUERY
@@ -23,24 +23,37 @@ RSpec.describe Types::QueryType do
       BackendSchema.execute(query)
     end
 
-    it '全てのjournalを取得できる' do
-      expect(result.dig('data', 'journals').size).to eq(Journal.count)
-    end
-
-    it '任意のjournalについてモデルと一致する内容を取得できる' do
-      random_journal = Journal.all.sample
-      expect(result.dig('data', 'journals').find { |journal| journal['id'] == random_journal.id.to_s }).to eq(
-        'id' => random_journal.id.to_s,
-        'title' => random_journal.title,
-        'content' => random_journal.content,
-        'userId' => random_journal.user_id
+    it '全てのjournalを取得できること' do
+      expect(result.fetch('data')).to eq(
+        {
+          'journals' => [
+            {
+              'id' => journal1.id.to_s,
+              'title' => 'タイトル1',
+              'content' => '内容1',
+              'userId' => journal1.user_id
+            },
+            {
+              'id' => journal2.id.to_s,
+              'title' => 'タイトル2',
+              'content' => '内容2',
+              'userId' => journal2.user_id
+            },
+            {
+              'id' => journal3.id.to_s,
+              'title' => 'タイトル3',
+              'content' => '内容3',
+              'userId' => journal3.user_id
+            }
+          ]
+        }
       )
     end
   end
 
   describe 'journal' do
-    let(:journal) { create(:journal) }
-    let(:journal_id) { journal.id }
+    let!(:journal) { create(:journal, title: 'タイトル', content: '内容') }
+    let!(:journal_id) { journal.id }
 
     let(:query) do
       <<~QUERY
@@ -65,7 +78,14 @@ RSpec.describe Types::QueryType do
     end
 
     it 'idで指定したjournalを取得できる' do
-      expect(result.dig('data', 'journal', 'id')).to eq(journal_id.to_s)
+      expect(result.fetch('data')).to eq(
+        'journal' => {
+          'id' => journal_id.to_s,
+          'title' => 'タイトル',
+          'content' => '内容',
+          'userId' => journal.user_id
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
## 何を解決するのか(関連するissueへのリンク等)
取得できるJournalのレコードの値まで検証できる。

## 実装の内容や理由（コードからは読み取れない情報を書きましょう）
クエリで取得できるJournalの値が期待通りかを検証するため、期待する値をベタ下書きして
検証するようにした。

Journalのレコードを作成する際、journal1, journal2と冗長な書き方をしているがDRYであることよりも
テストにおいては可読性が高く、正しく検証できていることを優先した。
Journalのid, user_idは自動発番される値のためベタ書きにしていない。

[伊藤さんの参考記事](https://qiita.com/jnchito/items/31cb4a92d7d0af9def36)

## 不安なところ・レビューしてもらいたいところ
検証できているかどうか


