### PR TITLE
指定したユーザーのjournal全てを取得する

### DIFF
--- a/backend/app/graphql/types/query_type.rb
+++ b/backend/app/graphql/types/query_type.rb
@@ -9,12 +9,20 @@ module Types
       argument :id, ID, required: true
     end
 
+    field :user_journals, [Types::JournalType], null: false do
+      argument :user_id, ID, required: true
+    end
+
     def journals
       Journal.all
     end
 
     def journal(id:)
       Journal.find(id)
+    end
+
+    def user_journals(user_id:)
+      Journal.where(user_id:)
     end
   end
 end

--- a/backend/spec/graphql/types/query_type_spec.rb
+++ b/backend/spec/graphql/types/query_type_spec.rb
@@ -68,4 +68,46 @@ RSpec.describe Types::QueryType do
       expect(result.dig('data', 'journal', 'id')).to eq(journal_id.to_s)
     end
   end
+
+  describe 'user_journals' do
+    let(:user) { create(:user) }
+    let(:user_id) { user.id }
+    let(:journals) { create_list(:journal, 3, user:) }
+
+    let(:query) do
+      <<~QUERY
+        query GetUserJournals($userId: ID!) {
+          userJournals(userId: $userId) {
+            id
+            title
+            content
+            userId
+          }
+        }
+      QUERY
+    end
+
+    let(:result) do
+      BackendSchema.execute(
+        query,
+        variables: {
+          userId: user_id
+        }
+      )
+    end
+
+    it 'userIdで指定したuserのjournalを取得できる' do
+      expect(result.dig('data', 'userJournals').size).to eq(journals.size)
+    end
+
+    it '任意のjournalについてモデルと一致する内容を取得できる' do
+      random_journal = journals.sample
+      expect(result.dig('data', 'userJournals').find { |journal| journal['id'] == random_journal.id.to_s }).to eq(
+        'id' => random_journal.id.to_s,
+        'title' => random_journal.title,
+        'content' => random_journal.content,
+        'userId' => random_journal.user_id
+      )
+    end
+  end
 end


### PR DESCRIPTION
## 何を解決するのか(関連するissueへのリンク等)
指定したユーザーのjournal全てを取得してくるぞい

【複数作業あり】Userの詳細ページを作る · Issue https://github.com/yuki-snow1823/diary/issues/104

## 実装の内容や理由（コードからは読み取れない情報を書きましょう）
<img width="1124" alt="スクリーンショット 2023-08-13 9 36 31" src="https://github.com/yuki-snow1823/diary/assets/59280290/7323d41f-b6ff-4700-8b2c-9ae36a84796c">

## 不安なところ・レビューしてもらいたいところ
これまでの実装を流用しているので、特になしです
