### PR TITLE
StrictModeがONだとリクエストが2回走り、それによってセッションが切れていた

### DIFF
--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.

--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  config.change_headers_on_each_request = false
+  # config.change_headers_on_each_request = ture
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,7 +5,5 @@ import 'styles.css'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
-  <React.StrictMode>
     <App />
-  </React.StrictMode>
 )

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,6 +4,4 @@ import App from 'App'
 import 'styles.css'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
-root.render(
-    <App />
-)
+root.render(<App />)


### PR DESCRIPTION
## 何を解決するのか(関連するissueへのリンク等)
fix: #133
fix: #141

## 実装の内容や理由（コードからは読み取れない情報を書きましょう）
https://zenn.dev/haze_it_ac/articles/06a8110234451e

この記事を参考にしました。

引用：

![image](https://github.com/yuki-snow1823/diary/assets/59280290/c149e9a3-3728-4486-bb99-d3d8ebdbd7f6)

結果的にこれと同じ気がする...
何故か2回リクエストが走っているから、その原因を探す必要があります。また別issueにて

→その後、React18でStrictModeをオン

## 不安なところ・レビューしてもらいたいところ

